### PR TITLE
Flatpak exportable action icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,22 +47,22 @@ install : iwgtk iwgtk.1.gz
 	install -d $(DESTDIR)$(svg_icon_dir)/apps
 	install icons/iwgtk.svg $(DESTDIR)$(svg_icon_dir)/apps
 	install -d $(DESTDIR)$(svg_icon_dir)/actions
-	install icons/unknown.svg $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-down.svg
-	install icons/connecting.svg $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-connecting.svg
-	install icons/connected.svg $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-up.svg
-	install icons/ap-down.svg $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-ap-down.svg
-	install icons/ap-up.svg $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-ap-up.svg
+	install icons/unknown.svg $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-down.svg
+	install icons/connecting.svg $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-connecting.svg
+	install icons/connected.svg $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-up.svg
+	install icons/ap-down.svg $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.ap-down.svg
+	install icons/ap-up.svg $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.ap-up.svg
 
 uninstall :
 	rm $(DESTDIR)$(bindir)/iwgtk
 	rm $(DESTDIR)$(desktopdir)/iwgtk.desktop
 	rm $(DESTDIR)$(man1dir)/iwgtk.1.gz
 	rm $(DESTDIR)$(svg_icon_dir)/apps/iwgtk.svg
-	rm $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-down.svg
-	rm $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-connecting.svg
-	rm $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-station-up.svg
-	rm $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-ap-down.svg
-	rm $(DESTDIR)$(svg_icon_dir)/actions/iwgtk-ap-up.svg
+	rm $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-down.svg
+	rm $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-connecting.svg
+	rm $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.station-up.svg
+	rm $(DESTDIR)$(svg_icon_dir)/actions/icom.github.j_lentz.wgtk-ap-down.svg
+	rm $(DESTDIR)$(svg_icon_dir)/actions/com.github.j_lentz.iwgtk.ap-up.svg
 
 clean :
 	rm -f iwgtk *.o $(srcdir)/icons.c $(srcdir)/icons.h iwgtk.1.gz

--- a/src/indicator.c
+++ b/src/indicator.c
@@ -58,15 +58,15 @@ void indicator_set_station(Indicator *indicator) {
     state = g_variant_get_string(state_var, NULL);
 
     if (!strcmp(state, "connected")) {
-	icon_name = "iwgtk-station-up";
+	icon_name = "com.github.j_lentz.iwgtk.station-up";
 	icon_desc = "Connected to wifi network";
     }
     else if (!strcmp(state, "connecting")) {
-	icon_name = "iwgtk-station-connecting";
+	icon_name = "com.github.j_lentz.iwgtk.station-connecting";
 	icon_desc = "Connecting to wifi network";
     }
     else {
-	icon_name = "iwgtk-station-down";
+	icon_name = "com.github.j_lentz.iwgtk.station-down";
 	icon_desc = "Not connected to a wifi network";
     }
 
@@ -89,11 +89,11 @@ void indicator_set_ap(Indicator *indicator) {
     }
 
     if (started) {
-	icon_name = "iwgtk-ap-up";
+	icon_name = "com.github.j_lentz.iwgtk.ap-up";
 	icon_desc = "AP is up";
     }
     else {
-	icon_name = "iwgtk-ap-down";
+	icon_name = "com.github.j_lentz.iwgtk.ap-down";
 	icon_desc = "AP is down";
     }
 
@@ -122,11 +122,11 @@ void indicator_set_adhoc(Indicator *indicator) {
     }
 
     if (started) {
-	icon_name = "iwgtk-ap-up";
+	icon_name = "com.github.j_lentz.iwgtk.ap-up";
 	icon_desc = "Ad-hoc node is up";
     }
     else {
-	icon_name = "iwgtk-ap-down";
+	icon_name = "com.github.j_lentz.iwgtk.ap-down";
 	icon_desc = "Ad-hoc node is down";
     }
 


### PR DESCRIPTION
This change follows Flatpak requirements for icon names, prefixed with the application id,  so the icons will be exported when packaging the app as a Flatpak using flatpak-builder.  
When the icons are exportable they will be available on the host so the system tray bar (StatusNotifierHost) will be able to access them.

I also opened a [bug report requesting a valid D-Bus name](https://github.com/J-Lentz/iwgtk/issues/5) that should be the same as the application id, but it's not blocking this PR.

The [Flatpak manifest](https://github.com/tinywrkb/flatpaks/blob/master/com.github.j_lentz.iwgtk/com.github.j_lentz.iwgtk.yaml) can be built with flatpak-builder, see [README.md](https://github.com/tinywrkb/flatpaks/blob/master/README.md).