### PR TITLE
Fixes bug that causes multiple windows to open if the window is open but does not have focus when clicking taskbar icon

### DIFF
--- a/src/indicator.c
+++ b/src/indicator.c
@@ -142,13 +142,13 @@ void indicator_activate(GDBusObject *device_object) {
 	Window *window;
 
 	window = global.windows;
-	while (window != NULL) {
-	    if (gtk_window_is_active(GTK_WINDOW(window->window))) {
-		gtk_widget_destroy(window->window);
-		return;
+        if (window != NULL) {
+	    while (window != NULL) {
+                gtk_widget_destroy(window->window);
+	        window = window->next;
 	    }
-	    window = window->next;
-	}
+            return;
+        }
     }
 
     /*


### PR DESCRIPTION
As the title suggests!

To reproduce this bug:
- Start iwgtk with `-i` flag
- Click icon, window opens
- Bring focus to ANY other window
- Click icon, a second window opens

I don't think this was intentional...? At least it's not what a user would expect I think. 😉
This pull request changes the behavior to simply close any open window(s) on click, and only opens a new one when none were closed.