### PR TITLE
refactor: replace deprecated GTK APIs with new ones

### DIFF
--- a/src/adhoc.c
+++ b/src/adhoc.c
@@ -74,7 +74,7 @@ void adhoc_dialog_launch(AdHoc *adhoc) {
     grid_column_set_alignment(table, 2, GTK_ALIGN_START);
 
     g_signal_connect_swapped(adhoc_dialog->window, "destroy", G_CALLBACK(g_free), adhoc_dialog);
-    gtk_widget_show(adhoc_dialog->window);
+    gtk_widget_set_visible(adhoc_dialog->window, true);
 }
 
 void adhoc_dialog_submit(AdHocDialog *adhoc_dialog) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -245,7 +245,7 @@ void request_dialog(Agent *agent, guint8 request_type) {
     grid_column_set_alignment(table, 1, GTK_ALIGN_START);
 
     g_signal_connect_swapped(agent->window, "destroy", G_CALLBACK(agent_window_destroy), agent);
-    gtk_widget_show(agent->window);
+    gtk_widget_set_visible(agent->window, true);
 }
 
 void request_submit(Agent *agent) {

--- a/src/ap.c
+++ b/src/ap.c
@@ -62,7 +62,7 @@ void ap_dialog_launch(AP *ap) {
     grid_column_set_alignment(table, 1, GTK_ALIGN_START);
 
     g_signal_connect_swapped(dialog->window, "destroy", G_CALLBACK(g_free), dialog);
-    gtk_widget_show(dialog->window);
+    gtk_widget_set_visible(dialog->window, true);
 }
 
 void ap_dialog_submit(APDialog *dialog) {
@@ -144,10 +144,10 @@ void ap_set(AP *ap) {
 	    gtk_label_set_text(GTK_LABEL(ap->ssid), ssid_label);
 	    g_free(ssid_label);
 
-	    gtk_widget_show(ap->ssid);
+	    gtk_widget_set_visible(ap->ssid, true);
 	}
 	else {
-	    gtk_widget_hide(ap->ssid);
+	    gtk_widget_set_visible(ap->ssid, false);
 	}
     }
 }
@@ -164,7 +164,7 @@ AP* ap_add(Window *window, GDBusObject *object, GDBusProxy *proxy) {
 
     ap->ssid = gtk_label_new(NULL);
     g_object_ref_sink(ap->ssid);
-    gtk_widget_hide(ap->ssid);
+    gtk_widget_set_visible(ap->ssid, false);
     gtk_widget_set_halign(ap->ssid, GTK_ALIGN_START);
 
     couple_register(window, DEVICE_AP, 1, ap, object);

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -130,7 +130,7 @@ void diagnostic_window_show(Diagnostic *diagnostic, GtkWidget *table) {
     }
 
     gtk_window_set_child(GTK_WINDOW(window), table);
-    gtk_widget_show(window);
+    gtk_widget_set_visible(window, true);
 }
 
 gboolean diagnostic_key_press(GtkEventControllerKey *controller, guint keyval, guint keycode, GdkModifierType state, GtkWindow *window) {

--- a/src/dpp.c
+++ b/src/dpp.c
@@ -100,7 +100,7 @@ GtkWidget* qrcode_widget_new(const gchar *uri) {
 	    context = gtk_widget_get_style_context(area);
 
 	    provider = gtk_css_provider_new();
-	    gtk_css_provider_load_from_data(provider, "* {background: white;}", -1);
+	    gtk_css_provider_load_from_string(provider, "* {background: white;}");
 	    gtk_style_context_add_provider(context, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_USER + 1);
 	    g_object_unref(provider);
 	}

--- a/src/hidden.c
+++ b/src/hidden.c
@@ -51,7 +51,7 @@ void hidden_ssid_dialog(Station *station) {
     grid_column_set_alignment(table, 1, GTK_ALIGN_START);
 
     g_signal_connect_swapped(dialog->window, "destroy", G_CALLBACK(g_free), dialog);
-    gtk_widget_show(dialog->window);
+    gtk_widget_set_visible(dialog->window, true);
 }
 
 void hidden_ssid_submit(HiddenNetworkDialog *dialog) {

--- a/src/known_network.c
+++ b/src/known_network.c
@@ -61,13 +61,7 @@ void known_network_set(KnownNetwork *kn) {
 	hidden_var = g_dbus_proxy_get_cached_property(kn->proxy, "Hidden");
 	hidden = g_variant_get_boolean(hidden_var);
 
-	if (hidden) {
-	    gtk_widget_show(kn->hidden_label);
-	}
-	else {
-	    gtk_widget_hide(kn->hidden_label);
-	}
-
+	gtk_widget_set_visible(kn->hidden_label, hidden);
 	g_variant_unref(hidden_var);
     }
 

--- a/src/station.c
+++ b/src/station.c
@@ -119,7 +119,7 @@ Station* station_add(Window *window, GDBusObject *object, GDBusProxy *proxy) {
     station->provision_button = gtk_button_new_with_label(_("Provision"));
     g_object_ref_sink(station->provision_button);
 
-    g_signal_connect_swapped(station->provision_button, "clicked", G_CALLBACK(gtk_widget_set_visible), station->provision_menu);
+    g_signal_connect_swapped(station->provision_button, "clicked", G_CALLBACK(gtk_popover_popup), station->provision_menu);
     gtk_widget_set_parent(station->provision_menu, station->provision_button);
 
     station->network_table = gtk_grid_new();

--- a/src/station.c
+++ b/src/station.c
@@ -119,7 +119,7 @@ Station* station_add(Window *window, GDBusObject *object, GDBusProxy *proxy) {
     station->provision_button = gtk_button_new_with_label(_("Provision"));
     g_object_ref_sink(station->provision_button);
 
-    g_signal_connect_swapped(station->provision_button, "clicked", G_CALLBACK(gtk_widget_show), station->provision_menu);
+    g_signal_connect_swapped(station->provision_button, "clicked", G_CALLBACK(gtk_widget_set_visible), station->provision_menu);
     gtk_widget_set_parent(station->provision_menu, station->provision_button);
 
     station->network_table = gtk_grid_new();

--- a/src/switch.c
+++ b/src/switch.c
@@ -68,6 +68,6 @@ GtkWidget* switch_new(GDBusProxy *proxy, const gchar *property) {
     gtk_widget_set_halign(switch_data->widget, GTK_ALIGN_CENTER);
     gtk_widget_set_valign(switch_data->widget, GTK_ALIGN_CENTER);
 
-    gtk_widget_show(switch_data->widget);
+    gtk_widget_set_visible(switch_data->widget, true);
     return switch_data->widget;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -132,7 +132,7 @@ void window_launch() {
 
     add_all_dbus_objects(window);
     g_signal_connect_swapped(window->window, "destroy", G_CALLBACK(window_rm), window);
-    gtk_widget_show(window->window);
+    gtk_widget_set_visible(window->window, true);
 }
 
 void window_rm(Window *window) {

--- a/src/wps.c
+++ b/src/wps.c
@@ -101,7 +101,7 @@ void wps_connect_pin_dialog(WPS *wps) {
     grid_column_set_alignment(table, 1, GTK_ALIGN_START);
 
     g_signal_connect_swapped(wps_dialog->window, "destroy", G_CALLBACK(g_free), wps_dialog);
-    gtk_widget_show(wps_dialog->window);
+    gtk_widget_set_visible(wps_dialog->window, true);
 }
 
 void wps_pin_dialog_submit(WPSDialog *wps_dialog) {


### PR DESCRIPTION
- [`gtk_widget_show()`](https://docs.gtk.org/gtk4/method.Widget.show.html) & [`gtk_widget_hide()`](https://docs.gtk.org/gtk4/method.Widget.hide.html) has been deprecated since GTK 4.10.
- [`gtk_css_provider_load_from_data()`](https://docs.gtk.org/gtk4/method.CssProvider.load_from_data.html) has been deprecated since GTK 4.12.