### PR TITLE
feat: add spacer between close and known networks buttons

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -109,6 +109,10 @@ void window_launch() {
 	    gtk_box_append(GTK_BOX(known_network_button_vbox), close_button);
 	}
 
+	GtkWidget *spacer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+	gtk_widget_set_size_request(spacer, -1, 3);
+	gtk_box_append(GTK_BOX(known_network_button_vbox), spacer);
+
 	gtk_box_append(GTK_BOX(known_network_button_vbox), window->known_network_button);
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -107,11 +107,8 @@ void window_launch() {
 	    close_button = gtk_button_new_with_label(_("Close"));
 	    g_signal_connect_swapped(close_button, "clicked", G_CALLBACK(gtk_window_destroy), window->window);
 	    gtk_box_append(GTK_BOX(known_network_button_vbox), close_button);
+		gtk_widget_set_margin_bottom(close_button, 3);
 	}
-
-	GtkWidget *spacer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_widget_set_size_request(spacer, -1, 3);
-	gtk_box_append(GTK_BOX(known_network_button_vbox), spacer);
 
 	gtk_box_append(GTK_BOX(known_network_button_vbox), window->known_network_button);
     }

--- a/src/window.c
+++ b/src/window.c
@@ -107,7 +107,7 @@ void window_launch() {
 	    close_button = gtk_button_new_with_label(_("Close"));
 	    g_signal_connect_swapped(close_button, "clicked", G_CALLBACK(gtk_window_destroy), window->window);
 	    gtk_box_append(GTK_BOX(known_network_button_vbox), close_button);
-		gtk_widget_set_margin_bottom(close_button, 3);
+	    gtk_widget_set_margin_bottom(close_button, 3);
 	}
 
 	gtk_box_append(GTK_BOX(known_network_button_vbox), window->known_network_button);


### PR DESCRIPTION
Adds a 3px space between the "Close" and "Known networks" buttons for having a consistent view with the "Scan" and "Provision" buttons.